### PR TITLE
Feat: metrics token

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -372,6 +372,10 @@ config:
       description: |
         Juju secret holding the Forgejo LFS_JWT_SECRET.
       type: secret
+    forgejo__metrics__token:
+      description: |
+        Juju secret holding the bearer token for the Forgejo /metrics endpoint.
+      type: secret
 
 assumes:
   - juju >= 3.5

--- a/src/charm.py
+++ b/src/charm.py
@@ -62,7 +62,6 @@ class ForgejoK8SOperatorCharm(ops.CharmBase):
         self._prometheus_scraping = MetricsEndpointProvider(
             self,
             relation_name="metrics-endpoint",
-            jobs=[{"static_configs": [{"targets": [f"*:{PORT}"]}]}],
             refresh_event=self.on.config_changed,
         )
         self._logging = LogForwarder(self, relation_name="logging")
@@ -253,6 +252,13 @@ class ForgejoK8SOperatorCharm(ops.CharmBase):
     def _on_secret_changed(self, e: ops.SecretChangedEvent) -> None:
         self.reconcile(e)
 
+    def _configure_prometheus(self, env_vars: dict):
+        job: dict = {"static_configs": [{"targets": [f"*:{PORT}"]}]}
+        if token := env_vars.get("FORGEJO__METRICS__TOKEN"):
+            job["authorization"] = {"credentials": token}
+
+        self._prometheus_scraping.update_scrape_job_spec([job])
+
     def reconcile(self, _: ops.EventBase) -> None:
         """Reconcile charm state: build env vars, update Pebble layer, and replan."""
         if not self.container.can_connect():
@@ -276,6 +282,9 @@ class ForgejoK8SOperatorCharm(ops.CharmBase):
 
             additional_env = self._build_additional_env(domain, protocol, tls_ready)
             env_vars = map_config_to_env_vars(self, **additional_env)
+            self._configure_ingress(domain, tls_ready)
+            self._configure_prometheus(env_vars)
+
             self._apply_pebble_layer(env_vars)
 
         # @TODO: Extend exception handling

--- a/src/charm.py
+++ b/src/charm.py
@@ -71,6 +71,8 @@ class ForgejoK8SOperatorCharm(ops.CharmBase):
 
         framework.observe(self.on.install, self._on_install)
         framework.observe(self.on.forgejo_pebble_ready, self.reconcile)
+        framework.observe(self.on.forgejo_pebble_check_failed, self._on_pebble_check_changed)
+        framework.observe(self.on.forgejo_pebble_check_recovered, self._on_pebble_check_changed)
         framework.observe(self.on.config_changed, self._on_config_changed)
         framework.observe(self.on.collect_unit_status, self._on_collect_status)
         framework.observe(getattr(self.on, "data_storage_attached"), self._on_storage_attached)
@@ -118,6 +120,9 @@ class ForgejoK8SOperatorCharm(ops.CharmBase):
     def database_name(self):
         """Return the database name scoped to this model and app."""
         return f"{self.model.name}-{self.app.name}"
+
+    def _on_pebble_check_changed(self, _: ops.EventBase) -> None:
+        """No-op: ops emits collect_unit_status automatically after every event."""
 
     def _on_collect_status(self, event: ops.CollectStatusEvent) -> None:
         """Collect and report the unit status."""
@@ -175,6 +180,10 @@ class ForgejoK8SOperatorCharm(ops.CharmBase):
         else:
             if not status.is_running():
                 event.add_status(ops.MaintenanceStatus("Waiting for Forgejo to start up"))
+                return
+            checks = self.container.get_checks("forgejo-ready")
+            if checks and checks["forgejo-ready"].status != ops.pebble.CheckStatus.UP:
+                event.add_status(ops.MaintenanceStatus("Waiting for Forgejo to be ready"))
 
     @property
     def _forgejo_version(self) -> Optional[str]:
@@ -211,6 +220,13 @@ class ForgejoK8SOperatorCharm(ops.CharmBase):
                     "group-id": FORGEJO_SYSTEM_GROUP_ID,
                     "working-dir": FORGEJO_DATA_DIR,
                     "environment": env_vars,
+                }
+            },
+            "checks": {
+                "forgejo-ready": {
+                    "override": "replace",
+                    "level": "ready",
+                    "http": {"url": f"http://localhost:{PORT}/api/healthz"},
                 }
             },
         }

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -3,10 +3,16 @@
 # See LICENSE file for licensing details.
 
 import logging
+import secrets
 import shutil
+import subprocess
+import time
+import urllib.error
+import urllib.request
 from pathlib import Path
 
 import pytest
+import pytest_asyncio
 import yaml
 from pytest_operator.plugin import OpsTest
 
@@ -16,22 +22,49 @@ METADATA = yaml.safe_load(Path("./charmcraft.yaml").read_text())
 APP_NAME = METADATA["name"]
 
 
-@pytest.mark.abort_on_fail
-async def test_build_and_deploy(ops_test: OpsTest):
-    """Build the charm-under-test and deploy it together with related charms.
+def _wait_for_forgejo_ready(ops_test: OpsTest, pod: str, timeout: int = 60) -> None:
+    """Block until Forgejo's health endpoint returns 200 inside *pod*.
 
-    Assert on the unit status before any relations/configurations take place.
+    Uses wget (present in Forgejo's Alpine image) to probe /api/healthz.
     """
-    # Copy source to a local temp directory
-    local_src = ops_test.tmp_path / "charm-src"
-    shutil.copytree(
-        ".",
-        local_src,
-        symlinks=True,
-        ignore=shutil.ignore_patterns(".git", ".tox", "parts", "stage", "prime", "*.charm"),
-    )
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        result = subprocess.run(
+            [
+                "kubectl",
+                "exec",
+                "-n",
+                ops_test.model_name,
+                pod,
+                "-c",
+                "forgejo",
+                "--",
+                "wget",
+                "-qO",
+                "/dev/null",
+                "http://localhost:3000/api/healthz",
+            ],
+            capture_output=True,
+            timeout=10,
+        )
+        if result.returncode == 0:
+            return
+        time.sleep(2)
+    raise TimeoutError(f"Forgejo in {pod} not healthy after {timeout}s")
 
-    # Build and deploy charm from local source folder
+
+@pytest_asyncio.fixture(scope="module")
+async def deployed_app(ops_test: OpsTest):
+    """Build and deploy the full charm stack; yield the forgejo-k8s Application object."""
+    local_src = ops_test.tmp_path / "charm-src"
+    if not local_src.exists():
+        shutil.copytree(
+            ".",
+            local_src,
+            symlinks=True,
+            ignore=shutil.ignore_patterns(".git", ".tox", "parts", "stage", "prime", "*.charm"),
+        )
+
     charm = await ops_test.build_charm(local_src)
     resources = {"forgejo-image": METADATA["resources"]["forgejo-image"]["upstream-source"]}
 
@@ -41,18 +74,82 @@ async def test_build_and_deploy(ops_test: OpsTest):
     await ops_test.model.deploy("postgresql-k8s", channel="14/stable", trust=True)
     await ops_test.model.integrate(f"{APP_NAME}:database", "postgresql-k8s:database")
 
-    # Wait for postgresql to be ready first, then check both apps together.
     await ops_test.model.wait_for_idle(
         apps=["postgresql-k8s"],
         status="active",
         raise_on_blocked=True,
         timeout=1000,
     )
-
-    # forgejo-k8s is expected to be blocked while postgresql is still allocating.
     await ops_test.model.wait_for_idle(
         apps=[APP_NAME, "postgresql-k8s"],
         status="active",
         raise_on_blocked=False,
         timeout=1000,
     )
+
+    yield ops_test.model.applications[APP_NAME]
+
+
+@pytest.mark.abort_on_fail
+async def test_build_and_deploy(deployed_app):
+    """Assert the deployed charm and its dependencies reach active status."""
+    assert deployed_app.status == "active"
+
+
+async def test_metrics_bearer_token(ops_test: OpsTest, deployed_app):
+    """Verify Forgejo enforces bearer-token auth on /metrics when configured."""
+    token = secrets.token_hex(16)
+
+    # Create a Juju user secret and grant it to the application.
+    return_code, stdout, stderr = await ops_test.juju(
+        "add-secret", "forgejo-metrics-token", f"value={token}"
+    )
+    assert return_code == 0, f"add-secret failed: {stderr}"
+    secret_id = stdout.strip()
+    logger.info("Created Juju secret %s", secret_id)
+
+    return_code, _, stderr = await ops_test.juju("grant-secret", secret_id, APP_NAME)
+    assert return_code == 0, f"grant-secret failed: {stderr}"
+
+    await deployed_app.set_config({"forgejo__metrics__token": secret_id})
+    await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=120)
+
+    # Wait until Forgejo is actually serving HTTP inside the pod.
+    forgejo_pod = f"{APP_NAME}-0"
+    _wait_for_forgejo_ready(ops_test, forgejo_pod)
+
+    # In microk8s, pod IPs are directly routable from the host.
+    pod_ip_result = subprocess.run(
+        [
+            "kubectl",
+            "get",
+            "pod",
+            "-n",
+            ops_test.model_name,
+            forgejo_pod,
+            "-o",
+            "jsonpath={.status.podIP}",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    pod_ip = pod_ip_result.stdout.strip()
+    metrics_url = f"http://{pod_ip}:3000/metrics"
+    logger.info("Testing /metrics at %s", metrics_url)
+
+    # Without bearer token: Forgejo should deny the request.
+    try:
+        urllib.request.urlopen(metrics_url, timeout=10)
+        assert False, "Expected 401 without bearer token, but got 200"
+    except urllib.error.HTTPError as e:
+        assert e.code == 401, f"Expected 401 without bearer token, got {e.code}"
+
+    # With the correct bearer token: Forgejo should serve metrics.
+    req = urllib.request.Request(metrics_url, headers={"Authorization": f"Bearer {token}"})
+    with urllib.request.urlopen(req, timeout=10) as resp:
+        assert resp.status == 200, f"Expected 200 with correct bearer token, got {resp.status}"
+
+    # Teardown: remove the token so the deploy is clean for any later tests.
+    await deployed_app.reset_config(["forgejo__metrics__token"])
+    await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=120)

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -6,7 +6,6 @@ import logging
 import secrets
 import shutil
 import subprocess
-import time
 import urllib.error
 import urllib.request
 from pathlib import Path
@@ -20,37 +19,6 @@ logger = logging.getLogger(__name__)
 
 METADATA = yaml.safe_load(Path("./charmcraft.yaml").read_text())
 APP_NAME = METADATA["name"]
-
-
-def _wait_for_forgejo_ready(ops_test: OpsTest, pod: str, timeout: int = 60) -> None:
-    """Block until Forgejo's health endpoint returns 200 inside *pod*.
-
-    Uses wget (present in Forgejo's Alpine image) to probe /api/healthz.
-    """
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        result = subprocess.run(
-            [
-                "kubectl",
-                "exec",
-                "-n",
-                ops_test.model_name,
-                pod,
-                "-c",
-                "forgejo",
-                "--",
-                "wget",
-                "-qO",
-                "/dev/null",
-                "http://localhost:3000/api/healthz",
-            ],
-            capture_output=True,
-            timeout=10,
-        )
-        if result.returncode == 0:
-            return
-        time.sleep(2)
-    raise TimeoutError(f"Forgejo in {pod} not healthy after {timeout}s")
 
 
 @pytest_asyncio.fixture(scope="module")
@@ -114,11 +82,8 @@ async def test_metrics_bearer_token(ops_test: OpsTest, deployed_app):
     await deployed_app.set_config({"forgejo__metrics__token": secret_id})
     await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=120)
 
-    # Wait until Forgejo is actually serving HTTP inside the pod.
-    forgejo_pod = f"{APP_NAME}-0"
-    _wait_for_forgejo_ready(ops_test, forgejo_pod)
-
     # In microk8s, pod IPs are directly routable from the host.
+    forgejo_pod = f"{APP_NAME}-0"
     pod_ip_result = subprocess.run(
         [
             "kubectl",

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -2,7 +2,7 @@
 # See LICENSE file for licensing details.
 #
 # To learn more about testing, see https://ops.readthedocs.io/en/latest/explanation/testing.html
-
+import json
 
 import pytest
 from ops import pebble, testing
@@ -124,6 +124,53 @@ def test_config_propagates_to_env_vars(monkeypatch: pytest.MonkeyPatch):
     assert env.get("FORGEJO__LOG__LEVEL") == "Debug"
     # Override mapping: dot in Forgejo section name encoded as _0X2E_
     assert env.get("FORGEJO__REPOSITORY_0X2E_PULL-REQUEST__DEFAULT_MERGE_STYLE") == "rebase"
+
+
+def test_metrics_scrape_jobs_no_token(monkeypatch: pytest.MonkeyPatch):
+    """Scrape jobs contain no authorization when no metrics token is configured."""
+    ctx = testing.Context(CharmForgejoCharm)
+    container_in = testing.Container("forgejo", can_connect=True)
+    metrics_relation = testing.Relation("metrics-endpoint")
+    state_in = testing.State(
+        containers={container_in},
+        relations={metrics_relation},
+        leader=True,
+    )
+    monkeypatch.setattr(
+        CharmForgejoCharm, "_forgejo_version", property(lambda self: mock_get_version())
+    )
+
+    state_out = ctx.run(ctx.on.config_changed(), state_in)
+
+    rel_out = state_out.get_relation(metrics_relation.id)
+    scrape_jobs = json.loads(rel_out.local_app_data.get("scrape_jobs", "[]"))
+    assert len(scrape_jobs) == 1
+    assert "authorization" not in scrape_jobs[0]
+
+
+def test_metrics_scrape_jobs_with_token(monkeypatch: pytest.MonkeyPatch):
+    """Scrape jobs include bearer-token authorization when the token secret is configured."""
+    ctx = testing.Context(CharmForgejoCharm)
+    container_in = testing.Container("forgejo", can_connect=True)
+    metrics_relation = testing.Relation("metrics-endpoint")
+    secret = testing.Secret(tracked_content={"value": "my-metrics-token"})
+    state_in = testing.State(
+        containers={container_in},
+        relations={metrics_relation},
+        secrets={secret},
+        config={"forgejo__metrics__token": secret.id},
+        leader=True,
+    )
+    monkeypatch.setattr(
+        CharmForgejoCharm, "_forgejo_version", property(lambda self: mock_get_version())
+    )
+
+    state_out = ctx.run(ctx.on.config_changed(), state_in)
+
+    rel_out = state_out.get_relation(metrics_relation.id)
+    scrape_jobs = json.loads(rel_out.local_app_data.get("scrape_jobs", "[]"))
+    assert len(scrape_jobs) == 1
+    assert scrape_jobs[0].get("authorization") == {"credentials": "my-metrics-token"}
 
 
 def test_secret_changed_triggers_reconcile(monkeypatch: pytest.MonkeyPatch):

--- a/tox.ini
+++ b/tox.ini
@@ -76,6 +76,7 @@ description = Run integration tests
 deps =
     pytest
     juju
+    pytest-asyncio
     pytest-operator
     -r {tox_root}/requirements.txt
 commands =


### PR DESCRIPTION
Charm was supporting Forgejo  `/metrics` without authentication. This MP adds a `BEARER_TOKEN` authentication support.