### PR TITLE
feat: ssh ingress

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -222,7 +222,14 @@ config:
       type: int
     forgejo__server__ssh_port:
       description: SSH port exposed to users for Git-over-SSH.
-      default: 22
+      default: 2222
+      type: int
+    forgejo__server__ssh_listen_port:
+      description: |
+        Internal port the built-in SSH server binds to inside the container.
+
+        Must be >1024 if Forgejo runs as a non-privileged user.
+      default: 2222
       type: int
     forgejo__server__lfs_start_server:
       description: Enable the built-in Git LFS server.

--- a/src/charm.py
+++ b/src/charm.py
@@ -21,7 +21,12 @@ from actions import (
     on_reset_user_password,
 )
 from certificates import CertHandler
-from config import ForgejoConfig, ForgejoStorageConfig, map_config_to_env_vars
+from config import (
+    ForgejoConfig,
+    ForgejoStorageConfig,
+    TraefikSSHConfig,
+    map_config_to_env_vars,
+)
 from constants import (
     CUSTOM_FORGEJO_CONFIG_FILE,
     ENVIRONMENT_TO_INI,
@@ -34,7 +39,7 @@ from constants import (
     PORT,
     SERVICE_NAME,
 )
-from ingress import get_traefik_route_config
+from ingress import get_ssh_static_config, get_traefik_route_config
 
 logger = logging.getLogger(__name__)
 
@@ -106,6 +111,11 @@ class ForgejoK8SOperatorCharm(ops.CharmBase):
         )
         framework.observe(self.database.on.database_created, self.reconcile)
         framework.observe(self.database.on.endpoints_changed, self.reconcile)
+
+        # ingress support
+        framework.observe(self.on["ingress"].relation_changed, self.reconcile)
+        framework.observe(self.on["ingress"].relation_departed, self.reconcile)
+        framework.observe(self.on["ingress"].relation_broken, self.reconcile)
 
         # S3 storage support
         self.s3_client = S3Requirer(self, relation_name="s3-credentials", bucket_name="forgejo")
@@ -254,6 +264,10 @@ class ForgejoK8SOperatorCharm(ops.CharmBase):
         # has explicitly set them via Juju config (empty string = use computed value).
         if not self.config.get("forgejo__server__root_url", ""):
             env["FORGEJO__SERVER__ROOT_URL"] = f"{protocol}://{domain}/"
+
+        ingress_cfg = TraefikSSHConfig.from_charm_config(self.config)
+        if ingress_cfg.ssh_enabled:
+            env["FORGEJO__SERVER__START_SSH_SERVER"] = "true"
         if tls_ready:
             env["FORGEJO__SERVER__PROTOCOL"] = "https"
             env["FORGEJO__SERVER__CERT_FILE"] = self.cert_handler.cert_path
@@ -292,6 +306,7 @@ class ForgejoK8SOperatorCharm(ops.CharmBase):
             domain = config.forgejo__server__domain
             protocol = "https" if tls_ready else "http"
 
+            self.set_ports()
             self._configure_ingress(domain, tls_ready)
 
             additional_env = self._build_additional_env(domain, protocol, tls_ready)
@@ -312,9 +327,22 @@ class ForgejoK8SOperatorCharm(ops.CharmBase):
         if not domain:
             logger.error("No domain set in charm")
             return
+        ingress_cfg = TraefikSSHConfig.from_charm_config(self.config)
         logger.info(f"Config domain {domain} is valid, submitting traefik route")
         self.ingress.submit_to_traefik(
-            get_traefik_route_config(self.model.name, self.app.name, domain, PORT, tls_ready)
+            get_traefik_route_config(
+                self.model.name,
+                self.app.name,
+                domain,
+                PORT,
+                tls_ready,
+                ingress_cfg.ssh_enabled,
+                ingress_cfg.ssh_port,
+                ingress_cfg.ssh_listen_port,
+            ),
+            static=get_ssh_static_config(ingress_cfg.ssh_port)
+            if ingress_cfg.ssh_enabled
+            else None,
         )
 
     def _apply_pebble_layer(self, env_vars: dict) -> None:
@@ -341,9 +369,10 @@ class ForgejoK8SOperatorCharm(ops.CharmBase):
 
     def set_ports(self):
         """Open necessary (and close no longer needed) workload ports."""
-        planned_ports = {
-            ops.model.OpenedPort("tcp", PORT),
-        }
+        ingress_cfg = TraefikSSHConfig.from_charm_config(self.config)
+        planned_ports = {ops.model.OpenedPort("tcp", PORT)}
+        if ingress_cfg.ssh_enabled:
+            planned_ports.add(ops.model.OpenedPort("tcp", ingress_cfg.ssh_listen_port))
         actual_ports = self.unit.opened_ports()
 
         # Ports may change across an upgrade, so need to sync

--- a/src/config.py
+++ b/src/config.py
@@ -138,3 +138,22 @@ class ForgejoStorageConfig(BaseModel):
             base_path=s3_info.get("path", ""),
             use_ssl=s3_info.get("use-ssl", "true").lower() == "true",
         )
+
+
+class TraefikSSHConfig(BaseModel):
+    """SSH-related Traefik ingress settings read from charm config."""
+
+    model_config = ConfigDict(frozen=True)
+
+    ssh_enabled: bool
+    ssh_port: int
+    ssh_listen_port: int
+
+    @classmethod
+    def from_charm_config(cls, config: ops.ConfigData) -> "TraefikSSHConfig":
+        """Build from the charm's live config."""
+        return cls(
+            ssh_enabled=not bool(config.get("forgejo__server__disable_ssh", False)),
+            ssh_port=int(config.get("forgejo__server__ssh_port", 2222)),
+            ssh_listen_port=int(config.get("forgejo__server__ssh_listen_port", 2222)),
+        )

--- a/src/ingress.py
+++ b/src/ingress.py
@@ -1,12 +1,94 @@
 """Traefik ingress route configuration for the Forgejo K8s charm."""
 
 
+def _k8s_service(app_name: str, model_name: str) -> str:
+    return f"{app_name}.{model_name}.svc.cluster.local"
+
+
+def _http_section(
+    router_name: str,
+    service_name: str,
+    domain: str,
+    k8s_svc: str,
+    port: int,
+) -> dict:
+    return {
+        "routers": {
+            router_name: {
+                "rule": f"Host(`{domain}`)",
+                "service": service_name,
+                "entryPoints": ["web"],
+            }
+        },
+        "services": {
+            service_name: {"loadBalancer": {"servers": [{"url": f"http://{k8s_svc}:{port}"}]}}
+        },
+    }
+
+
+def _tls_tcp_section(
+    router_name: str,
+    service_name: str,
+    domain: str,
+    k8s_svc: str,
+    port: int,
+) -> dict:
+    return {
+        "routers": {
+            router_name: {
+                "rule": f"HostSNI(`{domain}`)",
+                "service": service_name,
+                "entryPoints": ["websecure"],
+                "tls": {"passthrough": True},
+            }
+        },
+        "services": {
+            service_name: {"loadBalancer": {"servers": [{"address": f"{k8s_svc}:{port}"}]}}
+        },
+    }
+
+
+def _ssh_tcp_section(
+    router_name: str,
+    service_name: str,
+    k8s_svc: str,
+    ssh_listen_port: int,
+) -> dict:
+    return {
+        "routers": {
+            router_name: {
+                "rule": "HostSNI(`*`)",
+                "service": service_name,
+                "entryPoints": ["ssh"],
+            }
+        },
+        "services": {
+            service_name: {
+                "loadBalancer": {"servers": [{"address": f"{k8s_svc}:{ssh_listen_port}"}]}
+            }
+        },
+    }
+
+
+def get_ssh_static_config(ssh_port: int) -> dict:
+    """Return Traefik static config that declares the SSH TCP entrypoint.
+
+    When submitted via traefik_route, the traefik-k8s charm will add this
+    entrypoint to Traefik's static configuration and expose the port on
+    the Kubernetes LoadBalancer service automatically.
+    """
+    return {"entryPoints": {"ssh": {"address": f":{ssh_port}"}}}
+
+
 def get_traefik_route_config(
     model_name: str,
     app_name: str,
     domain: str,
     port: int,
     tls_enabled: bool = False,
+    ssh_enabled: bool = True,
+    ssh_port: int = 2222,
+    ssh_listen_port: int = 2222,
 ) -> dict:
     """Build a Traefik route configuration for Forgejo.
 
@@ -15,45 +97,29 @@ def get_traefik_route_config(
 
     HTTP mode: standard HTTP router forwarding to Forgejo.
     TLS mode: TCP TLS-passthrough router so Forgejo terminates TLS.
+    SSH mode: plain TCP router forwarding to Forgejo's SSH listener.
+      The Traefik entrypoint listens on *ssh_port* (external, user-facing) and
+      forwards to the backend on *ssh_listen_port* (internal container port).
+      Added to the config whenever *ssh_enabled* is True.
     """
-    router_name = f"{model_name}-{app_name}-router"
-    service_name = f"{model_name}-{app_name}-service"
-    k8s_service = f"{app_name}.{model_name}.svc.cluster.local"
+    prefix = f"{model_name}-{app_name}"
+    k8s_svc = _k8s_service(app_name, model_name)
 
     if tls_enabled:
-        return {
-            "tcp": {
-                "routers": {
-                    router_name: {
-                        "rule": f"HostSNI(`{domain}`)",
-                        "service": service_name,
-                        "entryPoints": ["websecure"],
-                        "tls": {"passthrough": True},
-                    }
-                },
-                "services": {
-                    service_name: {
-                        "loadBalancer": {
-                            "servers": [{"address": f"{k8s_service}:{port}"}],
-                        }
-                    }
-                },
-            }
-        }
+        tcp = _tls_tcp_section(f"{prefix}-router", f"{prefix}-service", domain, k8s_svc, port)
+        if ssh_enabled:
+            ssh = _ssh_tcp_section(
+                f"{prefix}-ssh-router", f"{prefix}-ssh-service", k8s_svc, ssh_listen_port
+            )
+            tcp["routers"].update(ssh["routers"])
+            tcp["services"].update(ssh["services"])
+        return {"tcp": tcp}
 
-    return {
-        "http": {
-            "routers": {
-                router_name: {
-                    "rule": f"Host(`{domain}`)",
-                    "service": service_name,
-                    "entryPoints": ["web"],
-                }
-            },
-            "services": {
-                service_name: {
-                    "loadBalancer": {"servers": [{"url": f"http://{k8s_service}:{port}"}]}
-                },
-            },
-        }
+    result = {
+        "http": _http_section(f"{prefix}-router", f"{prefix}-service", domain, k8s_svc, port)
     }
+    if ssh_enabled:
+        result["tcp"] = _ssh_tcp_section(
+            f"{prefix}-ssh-router", f"{prefix}-ssh-service", k8s_svc, ssh_listen_port
+        )
+    return result

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -1,20 +1,27 @@
 #!/usr/bin/env python3
 
 import logging
+import os
 import secrets
+import socket
 import subprocess
+import tempfile
+import time
 import urllib.error
 import urllib.request
 from pathlib import Path
 
 import jubilant
 import pytest
+import requests
 import yaml
 
 logger = logging.getLogger(__name__)
 
 METADATA = yaml.safe_load(Path("./charmcraft.yaml").read_text())
 APP_NAME = METADATA["name"]
+SSH_EXTERNAL_PORT = int(METADATA["config"]["options"]["forgejo__server__ssh_port"]["default"])
+FORGEJO_DOMAIN = METADATA["config"]["options"]["forgejo__server__domain"]["default"]
 
 
 @pytest.fixture(scope="module")
@@ -91,3 +98,172 @@ def test_metrics_bearer_token(deployed_app, juju: jubilant.Juju):
     # Teardown: remove the token so the deploy is clean for any later tests.
     juju.config(APP_NAME, reset=["forgejo__metrics__token"])
     juju.wait(lambda status: jubilant.all_active(status, APP_NAME), timeout=120)
+
+
+def _get_traefik_lb_ip(model: str, app_name: str = "traefik-k8s") -> str:
+    """Return the MetalLB LoadBalancer external IP for the traefik-k8s-lb service."""
+    result = subprocess.run(
+        [
+            "kubectl",
+            "get",
+            "service",
+            f"{app_name}-lb",
+            "-n",
+            model,
+            "-o",
+            "jsonpath={.status.loadBalancer.ingress[0].ip}",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout.strip()
+
+
+def _wait_for_ssh_banner(host: str, port: int, timeout: int = 300, interval: int = 5) -> None:
+    """Block until an SSH banner is received, proving Traefik is routing SSH to Forgejo."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            with socket.create_connection((host, port), timeout=5) as sock:
+                sock.settimeout(5)
+                data = sock.recv(256)
+                if data.startswith(b"SSH-"):
+                    return
+        except OSError:
+            pass
+        time.sleep(interval)
+    raise TimeoutError(f"No SSH banner from {host}:{port} after {timeout}s")
+
+
+@pytest.fixture(scope="module")
+def deployed_app_with_traefik(deployed_app, juju: jubilant.Juju):
+    """Extend the deployed app with Traefik; yield (app_name, traefik_lb_ip)."""
+    juju.deploy("traefik-k8s", channel="latest/stable", trust=True)
+    juju.integrate(f"{APP_NAME}:ingress", "traefik-k8s:traefik-route")
+
+    juju.wait(
+        lambda status: jubilant.all_active(status, APP_NAME, "postgresql-k8s", "traefik-k8s"),
+        timeout=600,
+    )
+
+    traefik_ip = _get_traefik_lb_ip(juju.model)
+    logger.info("Traefik LoadBalancer IP: %s", traefik_ip)
+
+    # Wait until Traefik is routing SSH to Forgejo (banner proves dynamic route is configured)
+    _wait_for_ssh_banner(traefik_ip, SSH_EXTERNAL_PORT, timeout=300)
+    logger.info(
+        "SSH banner received on %s:%d - Traefik route is active", traefik_ip, SSH_EXTERNAL_PORT
+    )
+
+    yield APP_NAME, traefik_ip
+
+    juju.remove_relation(f"{APP_NAME}:ingress", "traefik-k8s:traefik-route")
+    juju.remove_application("traefik-k8s")
+
+
+def test_ssh_push(deployed_app_with_traefik, juju: jubilant.Juju):
+    """Deploy Forgejo + Traefik, then create a repo and push a commit over SSH."""
+    app_name, traefik_ip = deployed_app_with_traefik
+    admin_user = "testadmin"
+    repo_name = "test-repo"
+
+    # Create admin user
+    juju.run(
+        f"{app_name}/leader",
+        "create-admin-user",
+        params={"username": admin_user, "email": "admin@test.local"},
+    )
+
+    # Generate an API token for the admin
+    task = juju.run(
+        f"{app_name}/leader",
+        "generate-user-token",
+        params={
+            "username": admin_user,
+            "token-name": "ssh-test-token",
+            "scopes": "all",
+        },
+    )
+    token = task.results["token"]
+
+    # Use traefik_ip for REST API calls; set Host header so Traefik routes correctly.
+    api_base = f"http://{traefik_ip}/api/v1"
+    auth_headers = {
+        "Authorization": f"token {token}",
+        "Content-Type": "application/json",
+        "Host": FORGEJO_DOMAIN,
+    }
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        key_path = os.path.join(tmpdir, "id_ed25519")
+        pub_key_path = f"{key_path}.pub"
+
+        # Generate SSH keypair
+        subprocess.run(
+            ["ssh-keygen", "-t", "ed25519", "-N", "", "-f", key_path],
+            check=True,
+            capture_output=True,
+        )
+        pub_key = Path(pub_key_path).read_text().strip()
+
+        # Register the public key with Forgejo
+        resp = requests.post(
+            f"{api_base}/user/keys",
+            headers=auth_headers,
+            json={"key": pub_key, "read_only": False, "title": "test-key"},
+            timeout=30,
+        )
+        assert resp.status_code == 201, f"Failed to add SSH key: {resp.text}"
+
+        # Create a new repository
+        resp = requests.post(
+            f"{api_base}/user/repos",
+            headers=auth_headers,
+            json={"name": repo_name, "private": False, "auto_init": False},
+            timeout=30,
+        )
+        assert resp.status_code == 201, f"Failed to create repository: {resp.text}"
+
+        # Clone, commit, and push over SSH via Traefik's LoadBalancer IP
+        repo_dir = os.path.join(tmpdir, repo_name)
+        os.makedirs(repo_dir)
+        ssh_cmd = f"ssh -i {key_path} -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null"
+        remote_url = f"ssh://git@{traefik_ip}:{SSH_EXTERNAL_PORT}/{admin_user}/{repo_name}.git"
+
+        env = {**os.environ, "GIT_SSH_COMMAND": ssh_cmd}
+        subprocess.run(["git", "init"], cwd=repo_dir, check=True, capture_output=True)
+        subprocess.run(
+            ["git", "config", "user.email", "admin@test.local"],
+            cwd=repo_dir,
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "Test Admin"],
+            cwd=repo_dir,
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "commit", "--allow-empty", "-m", "initial commit"],
+            cwd=repo_dir,
+            check=True,
+            capture_output=True,
+        )
+        subprocess.run(
+            ["git", "remote", "add", "origin", remote_url],
+            cwd=repo_dir,
+            check=True,
+            capture_output=True,
+        )
+        result = subprocess.run(
+            ["git", "push", "-u", "origin", "HEAD:main"],
+            cwd=repo_dir,
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, (
+            f"git push failed.\nstdout: {result.stdout}\nstderr: {result.stderr}"
+        )

--- a/tests/unit/test_ingress.py
+++ b/tests/unit/test_ingress.py
@@ -1,0 +1,122 @@
+"""Unit tests for src/ingress.py."""
+
+from ingress import get_ssh_static_config, get_traefik_route_config
+
+MODEL = "test-model"
+APP = "forgejo"
+DOMAIN = "git.example.com"
+PORT = 3000
+K8S = f"{APP}.{MODEL}.svc.cluster.local"
+
+
+# HTTP
+def test_http_route_has_http_and_tcp_sections():
+    config = get_traefik_route_config(MODEL, APP, DOMAIN, PORT)
+    assert "http" in config
+    assert "tcp" in config
+
+
+def test_http_router_rule_and_entrypoint():
+    config = get_traefik_route_config(MODEL, APP, DOMAIN, PORT)
+    router = config["http"]["routers"][f"{MODEL}-{APP}-router"]
+    assert router["rule"] == f"Host(`{DOMAIN}`)"
+    assert router["entryPoints"] == ["web"]
+
+
+def test_http_service_url():
+    config = get_traefik_route_config(MODEL, APP, DOMAIN, PORT)
+    service = config["http"]["services"][f"{MODEL}-{APP}-service"]
+    assert service["loadBalancer"]["servers"][0]["url"] == f"http://{K8S}:{PORT}"
+
+
+# TLS passthrough
+def test_tls_route_has_only_tcp_section():
+    config = get_traefik_route_config(MODEL, APP, DOMAIN, PORT, tls_enabled=True)
+    assert "http" not in config
+    assert "tcp" in config
+
+
+def test_tls_router_passthrough():
+    config = get_traefik_route_config(MODEL, APP, DOMAIN, PORT, tls_enabled=True)
+    router = config["tcp"]["routers"][f"{MODEL}-{APP}-router"]
+    assert router["rule"] == f"HostSNI(`{DOMAIN}`)"
+    assert router["entryPoints"] == ["websecure"]
+    assert router["tls"] == {"passthrough": True}
+
+
+def test_tls_service_address():
+    config = get_traefik_route_config(MODEL, APP, DOMAIN, PORT, tls_enabled=True)
+    service = config["tcp"]["services"][f"{MODEL}-{APP}-service"]
+    assert service["loadBalancer"]["servers"][0]["address"] == f"{K8S}:{PORT}"
+
+
+# SSH router (present by default, HTTP mode)
+def test_ssh_router_present_by_default():
+    config = get_traefik_route_config(MODEL, APP, DOMAIN, PORT)
+    assert f"{MODEL}-{APP}-ssh-router" in config["tcp"]["routers"]
+
+
+def test_ssh_router_rule_and_entrypoint():
+    config = get_traefik_route_config(MODEL, APP, DOMAIN, PORT)
+    router = config["tcp"]["routers"][f"{MODEL}-{APP}-ssh-router"]
+    assert router["rule"] == "HostSNI(`*`)"
+    assert router["entryPoints"] == ["ssh"]
+
+
+def test_ssh_service_address_default_port():
+    config = get_traefik_route_config(MODEL, APP, DOMAIN, PORT)
+    service = config["tcp"]["services"][f"{MODEL}-{APP}-ssh-service"]
+    assert service["loadBalancer"]["servers"][0]["address"] == f"{K8S}:2222"
+
+
+def test_ssh_service_address_custom_listen_port():
+    config = get_traefik_route_config(MODEL, APP, DOMAIN, PORT, ssh_listen_port=3022)
+    service = config["tcp"]["services"][f"{MODEL}-{APP}-ssh-service"]
+    assert service["loadBalancer"]["servers"][0]["address"] == f"{K8S}:3022"
+
+
+def test_ssh_service_address_external_port_does_not_affect_backend():
+    """ssh_port is for the Traefik entrypoint/clone URLs, not the backend address."""
+    config = get_traefik_route_config(MODEL, APP, DOMAIN, PORT, ssh_port=22, ssh_listen_port=2222)
+    service = config["tcp"]["services"][f"{MODEL}-{APP}-ssh-service"]
+    assert service["loadBalancer"]["servers"][0]["address"] == f"{K8S}:2222"
+
+
+# SSH disabled
+def test_ssh_disabled_no_tcp_section_in_http_mode():
+    config = get_traefik_route_config(MODEL, APP, DOMAIN, PORT, ssh_enabled=False)
+    assert "tcp" not in config
+
+
+def test_ssh_disabled_no_ssh_router_in_tls_mode():
+    config = get_traefik_route_config(
+        MODEL, APP, DOMAIN, PORT, tls_enabled=True, ssh_enabled=False
+    )
+    assert f"{MODEL}-{APP}-ssh-router" not in config["tcp"]["routers"]
+    assert f"{MODEL}-{APP}-ssh-service" not in config["tcp"]["services"]
+
+
+def test_ssh_disabled_tls_still_has_tls_router():
+    config = get_traefik_route_config(
+        MODEL, APP, DOMAIN, PORT, tls_enabled=True, ssh_enabled=False
+    )
+    assert f"{MODEL}-{APP}-router" in config["tcp"]["routers"]
+
+
+# TLS + SSH combined
+def test_tls_and_ssh_both_in_tcp_section():
+    config = get_traefik_route_config(
+        MODEL, APP, DOMAIN, PORT, tls_enabled=True, ssh_enabled=True, ssh_port=22
+    )
+    routers = config["tcp"]["routers"]
+    services = config["tcp"]["services"]
+    assert f"{MODEL}-{APP}-router" in routers
+    assert f"{MODEL}-{APP}-ssh-router" in routers
+    assert f"{MODEL}-{APP}-service" in services
+    assert f"{MODEL}-{APP}-ssh-service" in services
+
+
+# get_ssh_static_config
+def test_ssh_static_config_non_standard_port():
+    config = get_ssh_static_config(3022)
+    assert config["entryPoints"]["ssh"]["address"] == ":3022"

--- a/tox.ini
+++ b/tox.ini
@@ -74,6 +74,7 @@ deps =
     pytest ~= 9.0
     jubilant ~= 1.10
     pytest-jubilant ~= 2.0
+    requests ~= 2.34
     -r {tox_root}/requirements.txt
 pass_env =
     FORGEJO_IMAGE


### PR DESCRIPTION
Traefik routes SSH trafic to Forgejo SSH built-in server.

Includes a integration tests that:
- Deploys Forgejo, Traefik, PostgreSQL
- Integrates the charms
- Does Forgejo API calls to create a user and a repository
- Creates a SSH key
- Does Forgejo API calls to import the SSH key
- Pushes to the repository using SSH