### PR TITLE
fix: forgejo database port is configured via juju integration

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -401,11 +401,9 @@ class ForgejoK8SOperatorCharm(ops.CharmBase):
             if not data:
                 continue
             logger.info("New database endpoint is %s", data["endpoints"])
-            host, port = data["endpoints"].split(":")
             db_data = {
                 "FORGEJO__DATABASE__DB_TYPE": "postgres",
-                "FORGEJO__DATABASE__HOST": host,
-                "FORGEJO__DATABASE__PORT": port,
+                "FORGEJO__DATABASE__HOST": data["endpoints"],
                 "FORGEJO__DATABASE__NAME": self.database_name,
                 "FORGEJO__DATABASE__USER": data["username"],
                 "FORGEJO__DATABASE__PASSWD": data["password"],

--- a/tests/integration/test_pgbouncer.py
+++ b/tests/integration/test_pgbouncer.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+
+import logging
+from pathlib import Path
+
+import jubilant
+import pytest
+import yaml
+
+logger = logging.getLogger(__name__)
+
+METADATA = yaml.safe_load(Path("./charmcraft.yaml").read_text())
+APP_NAME = METADATA["name"]
+
+
+@pytest.fixture(scope="module")
+def deployed_app(charm: Path, juju: jubilant.Juju, forgejo_image):
+    """Deploy forgejo-k8s with pgbouncer-k8s as a database proxy."""
+    juju.deploy(
+        charm,
+        APP_NAME,
+        resources={"forgejo-image": forgejo_image},
+    )
+    juju.deploy("postgresql-k8s", channel="14/stable", trust=True)
+    juju.deploy("pgbouncer-k8s", channel="1/stable", trust=True)
+
+    juju.integrate("pgbouncer-k8s:backend-database", "postgresql-k8s:database")
+    juju.integrate(f"{APP_NAME}:database", "pgbouncer-k8s:database")
+
+    juju.wait(
+        lambda status: jubilant.all_active(status, APP_NAME, "pgbouncer-k8s", "postgresql-k8s"),
+        timeout=300,
+    )
+
+    yield APP_NAME
+
+
+def test_pgbouncer_database_proxy(deployed_app, juju: jubilant.Juju):
+    """Verify Forgejo reaches active status when its database is proxied through pgbouncer-k8s."""
+    status = juju.status()
+    assert jubilant.all_active(status, deployed_app, "pgbouncer-k8s", "postgresql-k8s")


### PR DESCRIPTION
It includes a integration test with the pgbouncer setup. Since postgresql charm does not allow to setup a custom port, it's testing:
- pgbouncer setup works
- forgejo database port works