### PR TITLE
feat: add http proxy support

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -382,6 +382,24 @@ config:
       description: |
         Juju secret holding the bearer token for the Forgejo /metrics endpoint.
       type: secret
+    http_proxy:
+      description: |
+        HTTP proxy URL to use for outbound connections from Forgejo (sets the HTTP_PROXY
+        env var).
+      default: ""
+      type: string
+    https_proxy:
+      description: |
+        HTTPS proxy URL to use for outbound connections from Forgejo (sets the HTTPS_PROXY
+        env var).
+      default: ""
+      type: string
+    no_proxy:
+      description: |
+        Comma-separated list of hosts or CIDR ranges that should bypass the proxy (sets the
+        NO_PROXY env var).
+      default: ""
+      type: string
 
 assumes:
   - juju >= 3.5

--- a/src/config.py
+++ b/src/config.py
@@ -17,6 +17,9 @@ _CONFIG_KEY_OVERRIDES: dict[str, str] = {
     "forgejo__cron__update_checker__enabled": "FORGEJO__CRON_0X2E_UPDATE_CHECKER__ENABLED",
     "forgejo__repository__signing__default_trust_model": "FORGEJO__REPOSITORY_0X2E_SIGNING__DEFAULT_TRUST_MODEL",  # noqa: E501
     "forgejo__repository__pull_request__default_merge_style": "FORGEJO__REPOSITORY_0X2E_PULL-REQUEST__DEFAULT_MERGE_STYLE",  # noqa: E501
+    "http_proxy": "HTTP_PROXY",
+    "https_proxy": "HTTPS_PROXY",
+    "no_proxy": "NO_PROXY",
 }
 
 


### PR DESCRIPTION
Add http_proxy, https_proxy and no_proxy charm configs. They populate the corresponding environment variables.