### PR TITLE
fix: use ssh_listen_port for Traefik SSH entrypoint

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -337,10 +337,9 @@ class ForgejoK8SOperatorCharm(ops.CharmBase):
                 PORT,
                 tls_ready,
                 ingress_cfg.ssh_enabled,
-                ingress_cfg.ssh_port,
                 ingress_cfg.ssh_listen_port,
             ),
-            static=get_ssh_static_config(ingress_cfg.ssh_port)
+            static=get_ssh_static_config(ingress_cfg.ssh_listen_port)
             if ingress_cfg.ssh_enabled
             else None,
         )

--- a/src/ingress.py
+++ b/src/ingress.py
@@ -87,7 +87,6 @@ def get_traefik_route_config(
     port: int,
     tls_enabled: bool = False,
     ssh_enabled: bool = True,
-    ssh_port: int = 2222,
     ssh_listen_port: int = 2222,
 ) -> dict:
     """Build a Traefik route configuration for Forgejo.
@@ -98,8 +97,8 @@ def get_traefik_route_config(
     HTTP mode: standard HTTP router forwarding to Forgejo.
     TLS mode: TCP TLS-passthrough router so Forgejo terminates TLS.
     SSH mode: plain TCP router forwarding to Forgejo's SSH listener.
-      The Traefik entrypoint listens on *ssh_port* (external, user-facing) and
-      forwards to the backend on *ssh_listen_port* (internal container port).
+      The Traefik entrypoint listens on *ssh_listen_port* and forwards to the
+      backend on the same port (internal container port).
       Added to the config whenever *ssh_enabled* is True.
     """
     prefix = f"{model_name}-{app_name}"

--- a/tests/unit/test_ingress.py
+++ b/tests/unit/test_ingress.py
@@ -75,13 +75,6 @@ def test_ssh_service_address_custom_listen_port():
     assert service["loadBalancer"]["servers"][0]["address"] == f"{K8S}:3022"
 
 
-def test_ssh_service_address_external_port_does_not_affect_backend():
-    """ssh_port is for the Traefik entrypoint/clone URLs, not the backend address."""
-    config = get_traefik_route_config(MODEL, APP, DOMAIN, PORT, ssh_port=22, ssh_listen_port=2222)
-    service = config["tcp"]["services"][f"{MODEL}-{APP}-ssh-service"]
-    assert service["loadBalancer"]["servers"][0]["address"] == f"{K8S}:2222"
-
-
 # SSH disabled
 def test_ssh_disabled_no_tcp_section_in_http_mode():
     config = get_traefik_route_config(MODEL, APP, DOMAIN, PORT, ssh_enabled=False)
@@ -105,9 +98,7 @@ def test_ssh_disabled_tls_still_has_tls_router():
 
 # TLS + SSH combined
 def test_tls_and_ssh_both_in_tcp_section():
-    config = get_traefik_route_config(
-        MODEL, APP, DOMAIN, PORT, tls_enabled=True, ssh_enabled=True, ssh_port=22
-    )
+    config = get_traefik_route_config(MODEL, APP, DOMAIN, PORT, tls_enabled=True, ssh_enabled=True)
     routers = config["tcp"]["routers"]
     services = config["tcp"]["services"]
     assert f"{MODEL}-{APP}-router" in routers


### PR DESCRIPTION
Use forgejo__server__ssh_listen_port for the Traefik static entrypoint, so ssh_port can be set independently for clone URLs.