### PR TITLE
fix: strip scheme from ForgejoStorageConfig.endpoint

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -8,7 +8,7 @@ import logging
 from typing import Literal
 
 import ops
-from pydantic import BaseModel, ConfigDict, Field, field_serializer
+from pydantic import BaseModel, ConfigDict, Field, field_serializer, field_validator
 
 logger = logging.getLogger(__name__)
 
@@ -123,6 +123,11 @@ class ForgejoStorageConfig(BaseModel):
     location: str = Field("", serialization_alias="FORGEJO__STORAGE__MINIO_LOCATION")
     base_path: str = Field("", serialization_alias="FORGEJO__STORAGE__MINIO_BASE_PATH")
     use_ssl: bool = Field(True, serialization_alias="FORGEJO__STORAGE__MINIO_USE_SSL")
+
+    @field_validator("endpoint", mode="before")
+    @classmethod
+    def _strip_scheme(cls, v: str) -> str:
+        return v.removeprefix("https://").removeprefix("http://")
 
     @field_serializer("use_ssl")
     def _ssl_to_str(self, value: bool) -> str:

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -84,6 +84,20 @@ def test_forgejo_storage_config_from_s3_info():
     assert cfg.use_ssl is True  # Default value
 
 
+@pytest.mark.parametrize("raw_endpoint", ["http://minio:9000", "https://minio:9000"])
+def test_forgejo_storage_config_endpoint_strips_scheme(raw_endpoint):
+    """Endpoint validator strips http:// and https:// prefixes."""
+    cfg = ForgejoStorageConfig(endpoint=raw_endpoint)
+    assert cfg.endpoint == "minio:9000"
+
+
+def test_forgejo_storage_config_from_s3_info_strips_scheme():
+    """from_s3_info strips http(s):// from the endpoint."""
+    s3_info = {"endpoint": "http://minio:9000", "access-key": "A", "secret-key": "S"}
+    cfg = ForgejoStorageConfig.from_s3_info(s3_info)
+    assert cfg.endpoint == "minio:9000"
+
+
 def _make_mock_charm(secret_id: str, content: dict | None) -> MagicMock:
     """Build a minimal mock charm whose model.get_secret returns a mock secret."""
     charm = MagicMock(spec=ops.CharmBase)


### PR DESCRIPTION
Forgejo's MinIO client expects a bare host:port endpoint with no URL scheme.