### PR TITLE
fix(pipeline): request full checkout for oci-image build

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -51,11 +51,12 @@ jobs:
     permissions:
       contents: read
       packages: write
-    uses: canonical/launchpad-actions/.github/workflows/oci-image.yaml@d37e57af16120fba0055931e77518a5f9edf7513
+    uses: canonical/launchpad-actions/.github/workflows/oci-image.yaml@799f7ca218f01a8375713b1afb99935f9f9e272a
     with:
       repo_url: ${{ inputs.upstream_url }}
       repo_branch: ${{ inputs.upstream_branch }}
       commit_sha: ${{ inputs.upstream_sha }}
+      full_checkout: true
 
   charm:
     uses: canonical/launchpad-actions/.github/workflows/build-charm.yaml@d37e57af16120fba0055931e77518a5f9edf7513


### PR DESCRIPTION
Forgejo derives its version via `git describe --tags` at build time. The reusable oci-image workflow now supports an opt-in full_checkout input to avoid the shallow clone that produces an invalid version string.